### PR TITLE
Configure npm publishing

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -10,16 +10,15 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
-    name: Release Version
+    name: Create Release
     runs-on: ubuntu-latest
 
     # Only run this job if one of the following is true:
-    # - It was done manually.
-    # - A non-fork, non-Dependabot PR was merged.
+    # - It was run manually.
+    # - A PR was merged that was not from Dependabot or a fork.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
@@ -28,13 +27,15 @@ jobs:
         github.event.pull_request.head.repo.fork == false
       )
 
+    outputs:
+      tag: v${{ steps.tag.outputs.version }}
+
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v4
         with:
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tag
         id: tag
@@ -50,8 +51,8 @@ jobs:
         with:
           tag: v${{ steps.tag.outputs.version }}
 
-  publish-github:
-    name: Publish to GitHub Packages
+  publish-npm:
+    name: Publish to npm
     runs-on: ubuntu-latest
 
     needs: release
@@ -63,28 +64,31 @@ jobs:
         with:
           fetch-tags: true
 
-      - name: Setup Node.js (npm)
-        id: setup-node-npm
+      - name: Setup Node.js
+        id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
           cache: npm
-          registry-url: https://registry.npmjs.org
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org/
 
       - name: Install Dependencies
         id: install
         run: npm ci
 
-      - name: Setup Node.js (gh-pkg)
-        id: setup-node-gh
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          registry-url: https://npm.pkg.github.com
+      - name: Test
+        id: test
+        run: npm ci-test
+
+      - name: Update npm Version
+        id: version
+        run:
+          npm version ${{ needs.release.outputs.tag }} --git-tag-version false
 
       - name: Publish
         id: publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm whoami
+          npm publish --ignore-scripts --access public

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -28,7 +25,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .node-version
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
   lint:
@@ -29,7 +26,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .node-version
           cache: npm
 
       - name: Install Dependencies

--- a/README.md
+++ b/README.md
@@ -100,15 +100,7 @@ For additional information about transpiled action code, see
 
 ## Installation
 
-### Option 1: Install from GitHub Packages
-
-1. [Authenticate to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)
-
-   ```bash
-   $ npm login --registry=https://npm.pkg.github.com
-   Username: <your username>
-   Password: <your personal access token>
-   ```
+### Option 1: Install from npm
 
 1. Install via `npm`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,
   "homepage": "https://github.com/github/local-action",
@@ -25,9 +25,6 @@
   },
   "bin": {
     "local-action": "./bin/local-action"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "ci-test": "NODE_OPTIONS=\"$NODE_OPTIONS --no-warnings --experimental-vm-modules\" jest --ci --reporters=default --reporters=jest-junit --no-cache",


### PR DESCRIPTION
This update configures publishing to npm as `@github/local-action`. There are some updates to the GitHub Actions workflows to support this.