### PR TITLE
Remove incorrect CWD setting

### DIFF
--- a/bin/local-action
+++ b/bin/local-action
@@ -59,7 +59,7 @@ function entrypoint() {
     }
 
     // Run the command.
-    execSync(command, { cwd: packagePath, stdio: 'inherit' })
+    execSync(command, { stdio: 'inherit' })
   } catch (error) {
     process.exit(error.status)
   } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,
   "homepage": "https://github.com/github/local-action",


### PR DESCRIPTION
This PR removes the setting that was incorrectly setting the CWD to the `local-action` path. This shouldn't be changed, as it should run from the location specified by the user.