### PR TITLE
Switch to correct input references

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "runtimeExecutable": "local-action",
       "cwd": "${workspaceRoot}",
-      "args": [".", "src/index.ts", ".env"],
+      "args": [".", "src/main.ts", ".env"],
       "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**", "node_modules/**"]
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,12 @@ your updates using the following GitHub Actions repositories:
    ```bash
    npm exec local-action \
    "/<action repository clone path>/typescript-action" \
-   "src/index.ts" \
+   "src/main.ts" \
    "<path to your .env file>"
 
    npm exec local-action \
    "/<action repository clone path>/javascript-action" \
-   "src/index.ts" \
+   "src/main.ts" \
    "<path to your .env file>"
    ```
 

--- a/README.md
+++ b/README.md
@@ -151,15 +151,15 @@ For additional information about transpiled action code, see
 
 ### `local-action run <path> <logic entrypoint> <dotenv file>`
 
-| Argument           | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `path`             | Path to the local action directory                         |
-|                    | Example: `/path/to/action.yml`                             |
-| `logic entrypoint` | Action logic entrypoint (relative to the action directory) |
-|                    | Example: `src/main.ts`                                     |
-| `dotenv file`      | Path to the local `.env` file for action inputs            |
-|                    | Example: `/path/to/.env`                                   |
-|                    | See the example [`.env.example`](.env.example)             |
+| Argument           | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `path`             | Path to the local action directory                     |
+|                    | Example: `/path/to/action.yml`                         |
+| `logic entrypoint` | Action logic entrypoint (relative to action directory) |
+|                    | Example: `src/main.ts`                                 |
+| `dotenv file`      | Path to the local `.env` file for action inputs        |
+|                    | Example: `/path/to/.env`                               |
+|                    | See the example [`.env.example`](.env.example)         |
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -149,31 +149,31 @@ For additional information about transpiled action code, see
 | `-h`, `--help`    | Display help information    |
 | `-V`, `--version` | Display version information |
 
-### `local-action run <path> <entrypoint> <dotenv file>`
+### `local-action run <path> <logic entrypoint> <dotenv file>`
 
-| Argument      | Description                                          |
-| ------------- | ---------------------------------------------------- |
-| `path`        | Path to the local action directory                   |
-|               | Example: `/path/to/action.yml`                       |
-| `entrypoint`  | Action entrypoint (relative to the action directory) |
-|               | Example: `src/index.ts`                              |
-| `dotenv file` | Path to the local `.env` file for action inputs      |
-|               | Example: `/path/to/.env`                             |
-|               | See the example [`.env.example`](.env.example)       |
+| Argument           | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `path`             | Path to the local action directory                         |
+|                    | Example: `/path/to/action.yml`                             |
+| `logic entrypoint` | Action logic entrypoint (relative to the action directory) |
+|                    | Example: `src/main.ts`                                     |
+| `dotenv file`      | Path to the local `.env` file for action inputs            |
+|                    | Example: `/path/to/.env`                                   |
+|                    | See the example [`.env.example`](.env.example)             |
 
 Examples:
 
 ```bash
-local-action run /path/to/typescript-action src/index.ts .env
+local-action run /path/to/typescript-action src/main.ts .env
 
 # The `run` action is invoked by default as well
-local-action /path/to/typescript-action src/index.ts .env
+local-action /path/to/typescript-action src/main.ts .env
 ```
 
 #### Output
 
 ```console
-$ local-action run /path/to/typescript-action src/index.ts .env
+$ local-action run /path/to/typescript-action src/main.ts .env
      _        _   _               ____       _
     / \   ___| |_(_) ___  _ __   |  _ \  ___| |__  _   _  __ _  __ _  ___ _ __
    / _ \ / __| __| |/ _ \| '_ \  | | | |/ _ \ '_ \| | | |/ _` |/ _` |/ _ \ '__|
@@ -188,7 +188,7 @@ $ local-action run /path/to/typescript-action src/index.ts .env
 │ (index) │       Field        │                  Value                    │
 ├─────────┼────────────────────┼───────────────────────────────────────────┤
 │    0    │   'Action Path'    │       '/path/to/typescript-action'        │
-│    1    │    'Entrypoint'    │ '/path/to/typescript-action/src/index.ts' │
+│    1    │    'Entrypoint'    │ '/path/to/typescript-action/src/main.ts'  │
 │    2    │ 'Environment File' │   '/path/to/local-action-debugger/.env'   │
 └─────────┴────────────────────┴───────────────────────────────────────────┘
 

--- a/__tests__/command.test.ts
+++ b/__tests__/command.test.ts
@@ -59,7 +59,7 @@ describe('Commmand', () => {
       ).parseAsync(
         [
           './__fixtures__/typescript/success',
-          'src/index.ts',
+          'src/main.ts',
           './__fixtures__/typescript/success/.env.fixture'
         ],
         {
@@ -92,7 +92,7 @@ describe('Commmand', () => {
     it('Exits if no env-file argument is provided', async () => {
       await (
         await makeProgram()
-      ).parseAsync(['./__fixtures__/typescript/success', 'src/index.ts'], {
+      ).parseAsync(['./__fixtures__/typescript/success', 'src/main.ts'], {
         from: 'user'
       })
 
@@ -104,7 +104,7 @@ describe('Commmand', () => {
     it('Exits if the action path is not a directory', async () => {
       await expect(
         (await makeProgram()).parseAsync(
-          ['./package.json', 'src/index.ts', '.env'],
+          ['./package.json', 'src/main.ts', '.env'],
           {
             from: 'user'
           }
@@ -117,7 +117,7 @@ describe('Commmand', () => {
     it('Exits if the action path does not exist', async () => {
       await expect(
         (await makeProgram()).parseAsync(
-          ['/test/path/does/not/exist', 'src/index.ts', '.env'],
+          ['/test/path/does/not/exist', 'src/main.ts', '.env'],
           {
             from: 'user'
           }
@@ -130,7 +130,7 @@ describe('Commmand', () => {
     it('Exits if the action path does not contain an action.yml or action.yaml', async () => {
       await expect(
         (await makeProgram()).parseAsync(
-          ['./__fixtures__', 'src/index.ts', '.env'],
+          ['./__fixtures__', 'src/main.ts', '.env'],
           {
             from: 'user'
           }
@@ -156,7 +156,7 @@ describe('Commmand', () => {
     it('Throws if the dotenv file does not exist', async () => {
       await expect(
         (await makeProgram()).parseAsync(
-          ['./__fixtures__/typescript/success', 'src/index.ts', '.notreal.env'],
+          ['./__fixtures__/typescript/success', 'src/main.ts', '.notreal.env'],
           {
             from: 'user'
           }

--- a/__tests__/stubs/env-stubs.test.ts
+++ b/__tests__/stubs/env-stubs.test.ts
@@ -38,7 +38,7 @@ describe('Env', () => {
       EnvMeta.actionFile = 'action.yml'
       EnvMeta.actionPath = '/some/path'
       EnvMeta.dotenvFile = '.env'
-      EnvMeta.entrypoint = 'index.ts'
+      EnvMeta.entrypoint = 'main.ts'
       EnvMeta.env = { TEST: 'test' }
       EnvMeta.inputs = { input: { description: 'test input' } }
       EnvMeta.outputs = { output: { description: 'test output' } }
@@ -49,7 +49,7 @@ describe('Env', () => {
         actionFile: 'action.yml',
         actionPath: '/some/path',
         dotenvFile: '.env',
-        entrypoint: 'index.ts',
+        entrypoint: 'main.ts',
         env: { TEST: 'test' },
         inputs: { input: { description: 'test input' } },
         outputs: { output: { description: 'test output' } },

--- a/docs/debugging-in-vscode.md
+++ b/docs/debugging-in-vscode.md
@@ -14,7 +14,7 @@ action. The following can be used as an example.
       "request": "launch",
       "runtimeExecutable": "local-action",
       "cwd": "${workspaceRoot}",
-      "args": [".", "src/index.ts", ".env"],
+      "args": [".", "src/main.ts", ".env"],
       "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**", "node_modules/**"]
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type EnvMetadata = {
   /** Outputs defined in `action.yml` */
   outputs: { [key: string]: Output }
 
-  /** Pre-transpilation entrypoint for the action (e.g. `src/index.ts`) */
+  /** Pre-transpilation entrypoint for the action (e.g. `src/main.ts`) */
   entrypoint: string
 }
 


### PR DESCRIPTION
The docs and tests incorrectly reference the entrypoint input should be `index.ts` or `index.js`. This should actually be the file that exports the `run()` function, `main.ts`.