### PR TITLE
Fall back to default inputs

### DIFF
--- a/__tests__/stubs/core/core.test.ts
+++ b/__tests__/stubs/core/core.test.ts
@@ -178,6 +178,21 @@ describe('Core', () => {
         expect(getInput('test')).toEqual('test-lower')
       })
 
+      it('Gets default inputs', () => {
+        delete process.env.INPUT_TEST
+        delete process.env.INPUT_test
+
+        EnvMeta.inputs = {
+          test: {
+            description: 'test',
+            required: true,
+            default: 'default'
+          }
+        }
+
+        expect(getInput('test')).toEqual('default')
+      })
+
       it('Returns an empty string', () => {
         expect(getInput('test-input-missing')).toEqual('')
       })
@@ -214,6 +229,21 @@ describe('Core', () => {
         ])
       })
 
+      it('Gets default inputs', () => {
+        delete process.env.INPUT_TEST
+        delete process.env.INPUT_test
+
+        EnvMeta.inputs = {
+          test: {
+            description: 'test',
+            required: true,
+            default: 'default'
+          }
+        }
+
+        expect(getMultilineInput('test')).toEqual(['default'])
+      })
+
       it('Returns an empty list if the input is not found', () => {
         expect(getMultilineInput('test-input-missing')).toMatchObject([])
       })
@@ -244,6 +274,21 @@ describe('Core', () => {
 
         process.env.INPUT_test = 'false'
         expect(getBooleanInput('test')).toBeFalsy()
+      })
+
+      it('Gets default inputs', () => {
+        delete process.env.INPUT_TEST
+        delete process.env.INPUT_test
+
+        EnvMeta.inputs = {
+          test: {
+            description: 'test',
+            required: true,
+            default: 'false'
+          }
+        }
+
+        expect(getBooleanInput('test')).toEqual(false)
       })
 
       it('Throws an error if the input is required and not found', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,

--- a/src/stubs/core/core.ts
+++ b/src/stubs/core/core.ts
@@ -200,6 +200,11 @@ export function getInput(name: string, options?: InputOptions): string {
     process.env[`INPUT_${name.replace(/ /g, '_')}`] ||
     ''
 
+  // If the input is not present in the environment variables, it has not been
+  // set. In that case, check the default value.
+  if (input === '' && EnvMeta.inputs[name]?.default !== undefined)
+    input = EnvMeta.inputs[name].default.toString()
+
   // Throw an error if the input is required and not supplied
   if (options && options.required === true && input === '')
     throw new Error(`Input required and not supplied: ${name}`)
@@ -224,13 +229,21 @@ export function getMultilineInput(
   options?: InputOptions
 ): string[] {
   // Get input by name, split by newline, and filter out empty strings
-  const input: string[] = (
+  let input: string[] = (
     process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] ||
     process.env[`INPUT_${name.replace(/ /g, '_')}`] ||
     ''
   )
     .split('\n')
     .filter(x => x !== '')
+
+  // If the input is not present in the environment variables, it has not been
+  // set. In that case, check the default value.
+  if (input.length === 0 && EnvMeta.inputs[name]?.default !== undefined)
+    input = EnvMeta.inputs[name].default
+      .toString()
+      .split('\n')
+      .filter(x => x !== '')
 
   // Throw an error if the input is required and not supplied
   if (options && options.required === true && input.length === 0)
@@ -257,11 +270,16 @@ export function getBooleanInput(name: string, options?: InputOptions): boolean {
   // using proxyquire's `callThru()` option.
 
   // Get input by name, or an empty string if not found
-  const input: string = (
+  let input: string = (
     process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] ||
     process.env[`INPUT_${name.replace(/ /g, '_')}`] ||
     ''
   ).trim()
+
+  // If the input is not present in the environment variables, it has not been
+  // set. In that case, check the default value.
+  if (input === '' && EnvMeta.inputs[name]?.default !== undefined)
+    input = EnvMeta.inputs[name].default.trim()
 
   // Throw an error if the input is required and not supplied
   if (options && options.required === true && input === '')


### PR DESCRIPTION
This PR adds a check so that, if an input is not present in the environment variables, the default value is used from the `action.yml`/`action.yaml` file (if a default is present).