### PR TITLE
fix boolean handling

### DIFF
--- a/__tests__/stubs/core/core.test.ts
+++ b/__tests__/stubs/core/core.test.ts
@@ -291,12 +291,36 @@ describe('Core', () => {
         expect(getBooleanInput('test')).toEqual(false)
       })
 
+      it('Gets default inputs - with an unquoted boolean', () => {
+        delete process.env.INPUT_TEST
+        delete process.env.INPUT_test
+
+        EnvMeta.inputs = {
+          test: {
+            description: 'test',
+            required: true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            default: false
+          }
+        }
+
+        expect(getBooleanInput('test')).toEqual(false)
+      })
+
       it('Throws an error if the input is required and not found', () => {
         expect(() =>
           getBooleanInput('test-input-missing', {
             required: true
           })
         ).toThrow()
+      })
+      it('Does NOT throws an error if the input is not required and not found', () => {
+        expect(() =>
+          getBooleanInput('test-input-missing', {
+            required: false
+          })
+        ).not.toThrow()
       })
 
       it('Returns true or false for valid YAML boolean values', () => {

--- a/__tests__/stubs/core/core.test.ts
+++ b/__tests__/stubs/core/core.test.ts
@@ -299,9 +299,9 @@ describe('Core', () => {
           test: {
             description: 'test',
             required: true,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            default: false
+            // while the spec says that the default value should be a string
+            // the yaml parser will pass an unquoted `true` or `false` through as a boolean
+            default: false as any // eslint-disable-line @typescript-eslint/no-explicit-any
           }
         }
 
@@ -315,12 +315,14 @@ describe('Core', () => {
           })
         ).toThrow()
       })
-      it('Does NOT throws an error if the input is not required and not found', () => {
+      it('Throws an error if the input is NOT required and not found', () => {
+        // ideally this would not throw - and either coerce to false or return undefined
+        // but this will require upstream changes. See discussion at https://github.com/github/local-action/pull/140
         expect(() =>
           getBooleanInput('test-input-missing', {
             required: false
           })
-        ).not.toThrow()
+        ).toThrow()
       })
 
       it('Returns true or false for valid YAML boolean values', () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,

--- a/src/stubs/core/core.ts
+++ b/src/stubs/core/core.ts
@@ -265,7 +265,10 @@ export function getMultilineInput(
  * @param options The options for the input
  * @returns The value of the input
  */
-export function getBooleanInput(name: string, options?: InputOptions): boolean {
+export function getBooleanInput(
+  name: string,
+  options?: InputOptions
+): boolean | undefined {
   // This is effectively a copy of the actual `getInput` function, instead of
   // using proxyquire's `callThru()` option.
 
@@ -278,12 +281,18 @@ export function getBooleanInput(name: string, options?: InputOptions): boolean {
 
   // If the input is not present in the environment variables, it has not been
   // set. In that case, check the default value.
-  if (input === '' && EnvMeta.inputs[name]?.default !== undefined)
-    input = EnvMeta.inputs[name].default.trim()
+  if (input === '' && EnvMeta.inputs[name]?.default !== undefined) {
+    // we call .toString in case its a boolean
+    input = EnvMeta.inputs[name].default.toString().trim()
+  }
 
   // Throw an error if the input is required and not supplied
-  if (options && options.required === true && input === '')
-    throw new Error(`Input required and not supplied: ${name}`)
+  if (input === '')
+    if (options && options.required === true) {
+      throw new Error(`Input required and not supplied: ${name}`)
+    } else {
+      return undefined
+    }
 
   if (['true', 'True', 'TRUE'].includes(input)) return true
   if (['false', 'False', 'FALSE'].includes(input)) return false

--- a/src/stubs/core/core.ts
+++ b/src/stubs/core/core.ts
@@ -265,10 +265,7 @@ export function getMultilineInput(
  * @param options The options for the input
  * @returns The value of the input
  */
-export function getBooleanInput(
-  name: string,
-  options?: InputOptions
-): boolean | undefined {
+export function getBooleanInput(name: string, options?: InputOptions): boolean {
   // This is effectively a copy of the actual `getInput` function, instead of
   // using proxyquire's `callThru()` option.
 
@@ -291,7 +288,7 @@ export function getBooleanInput(
     if (options && options.required === true) {
       throw new Error(`Input required and not supplied: ${name}`)
     } else {
-      return undefined
+      // here is where we would ideally return either `false` or `undefined` but we'll need upstream changes
     }
 
   if (['true', 'True', 'TRUE'].includes(input)) return true


### PR DESCRIPTION
fixes 2 issues, although you may want to adjust how its done...

1 - optional booleans were throwing an error when empty. Not sure if you want to return undefined, or just default to false if empty.

2 - boolean defaults were causing issues when unquoted in the yaml file