### PR TITLE
Fix import path for win32 platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,


### PR DESCRIPTION
This PR fixes an incorrect import path for win32-based systems to ensure the correct, absolute path is provided to the action import logic.

Closes #123 