### PR TITLE
Quote paths to handle spaces

### DIFF
--- a/bin/local-action.js
+++ b/bin/local-action.js
@@ -36,8 +36,8 @@ function entrypoint() {
 
     // Require the bootstrap script in NODE_OPTIONS.
     process.env.NODE_OPTIONS = process.env.NODE_OPTIONS
-      ? `${process.env.NODE_OPTIONS} --require ${bootstrapPath}`
-      : `--require ${bootstrapPath}`
+      ? `${process.env.NODE_OPTIONS} --require "${bootstrapPath}"`
+      : `--require "${bootstrapPath}"`
 
     // Disable experimental warnings.
     process.env.NODE_NO_WARNINGS = 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,


### PR DESCRIPTION
When setting the bootstrap path value, it was not quoted which could result in errors as seen in #148 when the path includes space characters. This PR fixes the issue by quoting the path value.