### PR TITLE
Enable overwrite of values in `.env`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "2.6.3",
+      "version": "2.6.4",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -59,7 +59,10 @@ export async function action(): Promise<void> {
 
   // Load the environment file
   // @todo Load this into EnvMeta directly? What about secrets...
-  config({ path: path.resolve(process.cwd(), EnvMeta.dotenvFile) })
+  config({
+    path: path.resolve(process.cwd(), EnvMeta.dotenvFile),
+    override: true
+  })
 
   // Load action settings
   CoreMeta.stepDebug = process.env.ACTIONS_STEP_DEBUG === 'true'


### PR DESCRIPTION
This PR adds the `overwrite` configuration option when loading environment variables from the user's local `.env` file. This is restricted to the Node.js process `@github/local-action` runs in, so there is no risk of overwriting environment variables in the user's shell.

CC @githubdev58yashi

Closes #155 