### PR TITLE
Add testing job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,3 +43,75 @@ jobs:
       - name: Test
         id: test
         run: npm run ci-test
+
+  test-templates:
+    name: Test Actions Templates
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: local-action
+
+    steps:
+      - name: Checkout @github/local-action
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          path: local-action
+
+      - name: Checkout TypeScript Template
+        id: checkout-typescript
+        uses: actions/checkout@v4
+        with:
+          path: typescript-action
+          repository: actions/typescript-action
+
+      - name: Checkout JavaScript Template
+        id: checkout-javascript
+        uses: actions/checkout@v4
+        with:
+          path: javascript-action
+          repository: actions/javascript-action
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: local-action/.node-version
+          cache: npm
+          cache-dependency-path: local-action/package-lock.json
+
+      - name: Install @github/local-action Dependencies
+        id: install
+        run: npm ci
+
+      - name: Install TypeScript Template Dependencies
+        id: install-typescript
+        run: npm ci
+        working-directory: typescript-action
+
+      - name: Install JavaScript Template Dependencies
+        id: install-javascript
+        run: npm ci
+        working-directory: javascript-action
+
+      - name: Link @github/local-action
+        id: link
+        run: npm link
+
+      - name: Generate Dotenv File
+        id: dotenv
+        run: |
+          echo "ACTIONS_STEP_DEBUG=true" >> .env
+          echo "INPUT_MILLISECONDS=2400" >> .env
+
+      - name: Test TypeScript Action
+        id: test-typescript
+        run: npx @github/local-action . src/main.ts ../local-action/.env
+        working-directory: typescript-action
+
+      - name: Test JavaScript Action
+        id: test-javascript
+        run: npx @github/local-action . src/main.js ../local-action/.env
+        working-directory: javascript-action


### PR DESCRIPTION
This PR adds a CI job that tests any changes to `@github/local-action` against the template repositories below:

- [`actions/typescript-action`](https://github.com/actions/typescript-action)
- [`actions/javascript-action`](https://github.com/actions/javascript-action)