### PR TITLE
Add support for pre/post commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v4
+
+This version adds support for
+[`pre`](https://docs.github.com/en/actions/reference/metadata-syntax-for-github-actions#runspre)
+and
+[`post`](https://docs.github.com/en/actions/reference/metadata-syntax-for-github-actions#runspost)
+scripts for actions. These should follow the same structure as the `run` action
+code (see the
+[`README.md`](https://github.com/github/local-action#action-structure) for more
+details).
+
 ## v3
 
 This version adds **experimental** support for [pnpm](https://pnpm.io/) and

--- a/README.md
+++ b/README.md
@@ -182,31 +182,35 @@ For additional information about transpiled action code, see
 | `-h`, `--help`    | Display help information    |
 | `-V`, `--version` | Display version information |
 
-### `local-action run <path> <logic entrypoint> <dotenv file>`
+### `local-action run <path> <logic entrypoint> <dotenv file> [--pre <pre entrypoint>] [--post <post entrypoint>]`
 
-| Argument           | Description                                            |
-| ------------------ | ------------------------------------------------------ |
-| `path`             | Path to the local action directory                     |
-|                    | Example: `/path/to/action.yml`                         |
-| `logic entrypoint` | Action logic entrypoint (relative to action directory) |
-|                    | Example: `src/main.ts`                                 |
-| `dotenv file`      | Path to the local `.env` file for action inputs        |
-|                    | Example: `/path/to/.env`                               |
-|                    | See the example [`.env.example`](.env.example)         |
+| Argument                   | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `path`                     | Path to the local action directory                                  |
+|                            | Example: `/path/to/action.yml`                                      |
+| `logic entrypoint`         | Action logic entrypoint (relative to action directory)              |
+|                            | Example: `src/main.ts`                                              |
+| `dotenv file`              | Path to the local `.env` file for action inputs                     |
+|                            | Example: `/path/to/.env`                                            |
+|                            | See the example [`.env.example`](.env.example)                      |
+| `--pre <pre entrypoint>`   | (Optional) `pre` command entrypoint (relative to action directory)  |
+|                            | Example: `pre/main.ts`                                              |
+| `--post <post entrypoint>` | (Optional) `post` command entrypoint (relative to action directory) |
+|                            | Example: `post/main.ts`                                             |
 
 Examples:
 
 ```bash
-local-action run /path/to/typescript-action src/main.ts .env
+local-action run /path/to/typescript-action src/main.ts .env --pre pre/main.ts --post post/main.ts
 
 # The `run` action is invoked by default as well
-local-action /path/to/typescript-action src/main.ts .env
+local-action /path/to/typescript-action src/main.ts .env --pre pre/main.ts --post post/main.ts
 ```
 
 #### Output
 
 ```console
-$ local-action run /path/to/typescript-action src/main.ts .env
+$ local-action run /path/to/typescript-action src/main.ts .env --pre pre/main.ts --post post/main.ts
      _        _   _               ____       _
     / \   ___| |_(_) ___  _ __   |  _ \  ___| |__  _   _  __ _  __ _  ___ _ __
    / _ \ / __| __| |/ _ \| '_ \  | | | |/ _ \ '_ \| | | |/ _` |/ _` |/ _ \ '__|

--- a/__fixtures__/javascript-esm/success/post/index.js
+++ b/__fixtures__/javascript-esm/success/post/index.js
@@ -1,0 +1,3 @@
+const { run } = require('./main')
+
+run()

--- a/__fixtures__/javascript-esm/success/post/main.js
+++ b/__fixtures__/javascript-esm/success/post/main.js
@@ -1,0 +1,13 @@
+const { getInput, info, setOutput } = require('@actions/core')
+
+async function run() {
+  const myInput = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('JavaScript Action Succeeded!')
+}
+
+module.exports = {
+  run
+}

--- a/__fixtures__/javascript-esm/success/pre/index.js
+++ b/__fixtures__/javascript-esm/success/pre/index.js
@@ -1,0 +1,3 @@
+const { run } = require('./main')
+
+run()

--- a/__fixtures__/javascript-esm/success/pre/main.js
+++ b/__fixtures__/javascript-esm/success/pre/main.js
@@ -1,0 +1,13 @@
+const { getInput, info, setOutput } = require('@actions/core')
+
+async function run() {
+  const myInput = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('JavaScript Action Succeeded!')
+}
+
+module.exports = {
+  run
+}

--- a/__fixtures__/javascript/success/post/index.js
+++ b/__fixtures__/javascript/success/post/index.js
@@ -1,0 +1,3 @@
+const { run } = require('./main')
+
+run()

--- a/__fixtures__/javascript/success/post/main.js
+++ b/__fixtures__/javascript/success/post/main.js
@@ -1,0 +1,13 @@
+const { getInput, info, setOutput } = require('@actions/core')
+
+async function run() {
+  const myInput = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('JavaScript Action Succeeded!')
+}
+
+module.exports = {
+  run
+}

--- a/__fixtures__/javascript/success/pre/index.js
+++ b/__fixtures__/javascript/success/pre/index.js
@@ -1,0 +1,3 @@
+const { run } = require('./main')
+
+run()

--- a/__fixtures__/javascript/success/pre/main.js
+++ b/__fixtures__/javascript/success/pre/main.js
@@ -1,0 +1,13 @@
+const { getInput, info, setOutput } = require('@actions/core')
+
+async function run() {
+  const myInput = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('JavaScript Action Succeeded!')
+}
+
+module.exports = {
+  run
+}

--- a/__fixtures__/path.ts
+++ b/__fixtures__/path.ts
@@ -1,0 +1,7 @@
+import { jest } from '@jest/globals'
+
+export const resolve = jest.fn()
+
+export default {
+  resolve
+}

--- a/__fixtures__/typescript-esm/success/post/index.ts
+++ b/__fixtures__/typescript-esm/success/post/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main.js'
+
+run()

--- a/__fixtures__/typescript-esm/success/post/main.ts
+++ b/__fixtures__/typescript-esm/success/post/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript ESM Action Succeeded!')
+}

--- a/__fixtures__/typescript-esm/success/pre/index.ts
+++ b/__fixtures__/typescript-esm/success/pre/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main.js'
+
+run()

--- a/__fixtures__/typescript-esm/success/pre/main.ts
+++ b/__fixtures__/typescript-esm/success/pre/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript ESM Action Succeeded!')
+}

--- a/__fixtures__/typescript/success-yaml/post/index.ts
+++ b/__fixtures__/typescript/success-yaml/post/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main'
+
+run()

--- a/__fixtures__/typescript/success-yaml/post/main.ts
+++ b/__fixtures__/typescript/success-yaml/post/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript Action Succeeded!')
+}

--- a/__fixtures__/typescript/success-yaml/pre/index.ts
+++ b/__fixtures__/typescript/success-yaml/pre/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main'
+
+run()

--- a/__fixtures__/typescript/success-yaml/pre/main.ts
+++ b/__fixtures__/typescript/success-yaml/pre/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript Action Succeeded!')
+}

--- a/__fixtures__/typescript/success/post/index.ts
+++ b/__fixtures__/typescript/success/post/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main'
+
+run()

--- a/__fixtures__/typescript/success/post/main.ts
+++ b/__fixtures__/typescript/success/post/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript Action Succeeded!')
+}

--- a/__fixtures__/typescript/success/pre/index.ts
+++ b/__fixtures__/typescript/success/pre/index.ts
@@ -1,0 +1,3 @@
+import { run } from './main'
+
+run()

--- a/__fixtures__/typescript/success/pre/main.ts
+++ b/__fixtures__/typescript/success/pre/main.ts
@@ -1,0 +1,9 @@
+import { getInput, info, setOutput } from '@actions/core'
+
+export async function run(): Promise<void> {
+  const myInput: string = getInput('myInput')
+
+  setOutput('myOutput', myInput)
+
+  info('TypeScript Action Succeeded!')
+}

--- a/__tests__/command.test.ts
+++ b/__tests__/command.test.ts
@@ -1,7 +1,8 @@
 import { jest } from '@jest/globals'
 import { Command } from 'commander'
+import path from 'path'
 import { ResetCoreMetadata } from '../src/stubs/core/core.js'
-import { ResetEnvMetadata } from '../src/stubs/env.js'
+import { EnvMeta, ResetEnvMetadata } from '../src/stubs/env.js'
 
 const action = jest.fn()
 
@@ -15,15 +16,6 @@ const process_exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
   throw new Error(`process.exit()`)
 })
 
-const process_stderrSpy = jest
-  .spyOn(process.stderr, 'write')
-  .mockImplementation(() => true)
-
-let program: Command
-
-// Prevent output during tests
-jest.spyOn(console, 'log').mockImplementation(() => {})
-
 const { makeProgram } = await import('../src/command.js')
 
 describe('Commmand', () => {
@@ -31,9 +23,6 @@ describe('Commmand', () => {
     // Reset metadata
     ResetEnvMetadata()
     ResetCoreMetadata()
-
-    // Create a new program before each test
-    program = await makeProgram()
   })
 
   afterEach(() => {
@@ -41,146 +30,195 @@ describe('Commmand', () => {
   })
 
   describe('makeProgram()', () => {
-    it('Returns a Program', () => {
+    it('Returns a Program', async () => {
+      const program = await makeProgram()
+
       expect(program).not.toBe(null)
       expect(program).toBeInstanceOf(Command)
     })
 
-    it('Has a run command', () => {
+    it('Has a run command', async () => {
+      const program = await makeProgram()
+
       expect(program.commands.find(c => c.name() === 'run')).toBeInstanceOf(
         Command
       )
     })
 
     it('Runs if all arguments are provided (action.yml)', async () => {
-      await (
-        await makeProgram()
-      ).parseAsync(
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      program.parse(
         [
           './__fixtures__/typescript/success',
           'src/main.ts',
-          './__fixtures__/typescript/success/.env.fixture'
+          './__fixtures__/typescript/success/.env.fixture',
+          '--pre',
+          'pre/main.ts',
+          '--post',
+          'post/main.ts'
         ],
         {
           from: 'user'
         }
       )
 
-      expect(process_exitSpy).not.toHaveBeenCalled()
       expect(action).toHaveBeenCalled()
     })
 
     it('Runs if all arguments are provided (action.yaml)', async () => {
-      await (
-        await makeProgram()
-      ).parseAsync(
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve(
+        './__fixtures__/typescript/success-yaml'
+      )
+
+      program.parse(
         [
           './__fixtures__/typescript/success-yaml',
           'src/main.ts',
-          './__fixtures__/typescript/success-yaml/.env.fixture'
+          './__fixtures__/typescript/success-yaml/.env.fixture',
+          '--pre',
+          'pre/main.ts',
+          '--post',
+          'post/main.ts'
         ],
         {
           from: 'user'
         }
       )
 
-      expect(process_exitSpy).not.toHaveBeenCalled()
       expect(action).toHaveBeenCalled()
     })
 
     it('Exits if no path argument is provided', async () => {
-      await (await makeProgram()).parseAsync([], { from: 'user' })
+      const program = await makeProgram()
+
+      program.parse([], { from: 'user' })
 
       expect(process_exitSpy).toHaveBeenCalled()
-
-      process_stderrSpy.mockRestore()
     })
 
     it('Exits if no entrypoint argument is provided', async () => {
-      await (
-        await makeProgram()
-      ).parseAsync(['./__fixtures__/typescript/success', ''], { from: 'user' })
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      program.parse(['./__fixtures__/typescript/success', ''], { from: 'user' })
 
       expect(process_exitSpy).toHaveBeenCalled()
-
-      process_stderrSpy.mockRestore()
     })
 
     it('Exits if no env-file argument is provided', async () => {
-      await (
-        await makeProgram()
-      ).parseAsync(['./__fixtures__/typescript/success', 'src/main.ts'], {
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      program.parse(['./__fixtures__/typescript/success', 'src/main.ts'], {
         from: 'user'
       })
 
       expect(process_exitSpy).toHaveBeenCalled()
-
-      process_stderrSpy.mockRestore()
     })
 
     it('Exits if the action path is not a directory', async () => {
-      await expect(
-        (await makeProgram()).parseAsync(
-          ['./package.json', 'src/main.ts', '.env'],
-          {
-            from: 'user'
-          }
-        )
-      ).rejects.toThrow('Action path must be a directory')
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
 
-      process_stderrSpy.mockRestore()
+      expect(() => {
+        program.parse(['./package.json', 'src/main.ts', '.env'], {
+          from: 'user'
+        })
+      }).toThrow('Action path must be a directory')
     })
 
     it('Exits if the action path does not exist', async () => {
-      await expect(
-        (await makeProgram()).parseAsync(
-          ['/test/path/does/not/exist', 'src/main.ts', '.env'],
-          {
-            from: 'user'
-          }
-        )
-      ).rejects.toThrow('Action path does not exist')
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('/test/path/does/not/exist')
 
-      process_stderrSpy.mockRestore()
+      expect(() => {
+        program.parse(['/test/path/does/not/exist', 'src/main.ts', '.env'], {
+          from: 'user'
+        })
+      }).toThrow('Action path does not exist')
     })
 
     it('Exits if the action path does not contain an action.yml or action.yaml', async () => {
-      await expect(
-        (await makeProgram()).parseAsync(
-          ['./__fixtures__', 'src/main.ts', '.env'],
-          {
-            from: 'user'
-          }
-        )
-      ).rejects.toThrow('Path must contain an action.yml / action.yaml file')
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__')
 
-      process_stderrSpy.mockRestore()
+      expect(() => {
+        program.parse(['./__fixtures__', 'src/main.ts', '.env'], {
+          from: 'user'
+        })
+      }).toThrow('Path must contain an action.yml / action.yaml file')
     })
 
     it('Exits if the entrypoint does not exist', async () => {
-      await expect(
-        (await makeProgram()).parseAsync(
+      const program = await makeProgram()
+
+      expect(() => {
+        program.parse(
           ['./__fixtures__/typescript/success', 'src/fake.ts', '.env'],
           {
             from: 'user'
           }
         )
-      ).rejects.toThrow('Entrypoint does not exist')
+      }).toThrow('Entrypoint does not exist')
+    })
 
-      process_stderrSpy.mockRestore()
+    it('Exits if the pre entrypoint does not exist', async () => {
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      expect(() => {
+        program.parse(
+          [
+            './__fixtures__/typescript/success',
+            'src/main.ts',
+            './__fixtures__/typescript/success/.env.fixture',
+            '--pre',
+            'pre/fake.ts'
+          ],
+          {
+            from: 'user'
+          }
+        )
+      }).toThrow('PRE entrypoint does not exist')
+    })
+
+    it('Exits if the post entrypoint does not exist', async () => {
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      expect(() => {
+        program.parse(
+          [
+            './__fixtures__/typescript/success',
+            'src/main.ts',
+            './__fixtures__/typescript/success/.env.fixture',
+            '--pre',
+            'pre/main.ts',
+            '--post',
+            'post/fake.ts'
+          ],
+          {
+            from: 'user'
+          }
+        )
+      }).toThrow('POST entrypoint does not exist')
     })
 
     it('Throws if the dotenv file does not exist', async () => {
-      await expect(
-        (await makeProgram()).parseAsync(
+      const program = await makeProgram()
+      EnvMeta.actionPath = path.resolve('./__fixtures__/typescript/success')
+
+      expect(() => {
+        program.parse(
           ['./__fixtures__/typescript/success', 'src/main.ts', '.notreal.env'],
           {
             from: 'user'
           }
         )
-      ).rejects.toThrow('Environment file does not exist')
-
-      process_stderrSpy.mockRestore()
+      }).toThrow('Environment file does not exist')
     })
   })
 })

--- a/__tests__/stubs/env.test.ts
+++ b/__tests__/stubs/env.test.ts
@@ -13,7 +13,9 @@ const empty: EnvMetadata = {
   env: {},
   inputs: {},
   outputs: {},
-  path: ''
+  path: '',
+  preEntrypoint: undefined,
+  postEntrypoint: undefined
 }
 
 // Prevent output during tests

--- a/__tests__/utils/config.test.ts
+++ b/__tests__/utils/config.test.ts
@@ -1,0 +1,78 @@
+import { jest } from '@jest/globals'
+import * as path from '../../__fixtures__/path.js'
+import { ResetCoreMetadata } from '../../src/stubs/core/core.js'
+import { EnvMeta, ResetEnvMetadata } from '../../src/stubs/env.js'
+
+jest.unstable_mockModule('path', () => path)
+
+const { getOSEntrypoints } = await import('../../src/utils/config.js')
+
+describe('Config', () => {
+  beforeEach(() => {
+    // Reset metadata
+    ResetEnvMetadata()
+    ResetCoreMetadata()
+
+    path.resolve.mockImplementation(value => value)
+
+    EnvMeta.entrypoint = '/action/entrypoint.ts'
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getOSEntrypoints()', () => {
+    it('Gets the ESM entrypoints', () => {
+      EnvMeta.preEntrypoint = '/action/pre.ts'
+      EnvMeta.postEntrypoint = '/action/post.ts'
+
+      const result = getOSEntrypoints('esm')
+
+      expect(result).toEqual({
+        main: '/action/entrypoint.ts',
+        pre: '/action/pre.ts',
+        post: '/action/post.ts'
+      })
+    })
+
+    it('Gets the ESM entrypoints (undefined)', () => {
+      EnvMeta.preEntrypoint = undefined
+      EnvMeta.postEntrypoint = undefined
+
+      const result = getOSEntrypoints('esm')
+
+      expect(result).toEqual({
+        main: '/action/entrypoint.ts',
+        pre: undefined,
+        post: undefined
+      })
+    })
+
+    it('Gets the CJS entrypoints', () => {
+      EnvMeta.preEntrypoint = '/action/pre.ts'
+      EnvMeta.postEntrypoint = '/action/post.ts'
+
+      const result = getOSEntrypoints('cjs')
+
+      expect(result).toEqual({
+        main: '/action/entrypoint.ts',
+        pre: '/action/pre.ts',
+        post: '/action/post.ts'
+      })
+    })
+
+    it('Gets the CJS entrypoints (undefined)', () => {
+      EnvMeta.preEntrypoint = undefined
+      EnvMeta.postEntrypoint = undefined
+
+      const result = getOSEntrypoints('cjs')
+
+      expect(result).toEqual({
+        main: '/action/entrypoint.ts',
+        pre: undefined,
+        post: undefined
+      })
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "3.2.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.3.2",
@@ -4683,6 +4683,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
       "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
       "engines": {
         "node": ">=20"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,7 @@
 import { config } from 'dotenv'
 import { createRequire } from 'module'
 import { execSync } from 'node:child_process'
+import path from 'path'
 import * as quibble from 'quibble'
 import { ARTIFACT_STUBS } from '../stubs/artifact/artifact.js'
 import { CORE_STUBS, CoreMeta } from '../stubs/core/core.js'
@@ -8,17 +9,25 @@ import { EnvMeta } from '../stubs/env.js'
 import { Context } from '../stubs/github/context.js'
 import { getOctokit } from '../stubs/github/github.js'
 import type { Action } from '../types.js'
+import { getOSEntrypoints } from '../utils/config.ts'
 import { printTitle } from '../utils/output.js'
 import { isESM } from '../utils/package.js'
 
 const require = createRequire(import.meta.url)
 let needsReplug: boolean = false
 
-export async function action(): Promise<void> {
+export async function action(
+  actionPath: string,
+  entrypoint: string,
+  dotenvFile: string,
+  options: {
+    pre: string | undefined
+    post: string | undefined
+  }
+): Promise<void> {
   const { Chalk } = await import('chalk')
   const chalk = new Chalk()
   const fs = await import('fs')
-  const path = await import('path')
   const YAML = await import('yaml')
 
   CoreMeta.colors = {
@@ -35,28 +44,43 @@ export async function action(): Promise<void> {
   const actionType = isESM() ? 'esm' : 'cjs'
 
   // Output the configuration
-  printTitle(CoreMeta.colors.cyan, 'Configuration')
-  console.log()
-  console.table([
+  const startConfig = [
     {
       Field: 'Action Path',
-      Value: EnvMeta.actionPath
+      Value: actionPath
     },
     {
       Field: 'Entrypoint',
-      Value: EnvMeta.entrypoint
-    },
-    {
-      Field: 'Environment File',
-      Value: EnvMeta.dotenvFile
+      Value: entrypoint
     }
-  ])
+  ]
+
+  if (options.pre)
+    startConfig.push({
+      Field: 'Pre Entrypoint',
+      Value: options.pre
+    })
+
+  if (options.post)
+    startConfig.push({
+      Field: 'Post Entrypoint',
+      Value: options.post
+    })
+
+  startConfig.push({
+    Field: 'Environment File',
+    Value: dotenvFile
+  })
+
+  printTitle(CoreMeta.colors.cyan, 'Configuration')
+  console.log()
+  console.table(startConfig)
   console.log()
 
   // Load the environment file
   // @todo Load this into EnvMeta directly? What about secrets...
   config({
-    path: path.resolve(process.cwd(), EnvMeta.dotenvFile),
+    path: path.resolve(process.cwd(), dotenvFile),
     override: true
   })
 
@@ -117,7 +141,7 @@ export async function action(): Promise<void> {
   }
 
   // Starting at the target action's entrypoint, find the package.json file.
-  const dirs = path.dirname(EnvMeta.entrypoint).split(path.sep)
+  const dirs = path.dirname(entrypoint).split(path.sep)
   let packageJsonPath
   let found = false
 
@@ -155,7 +179,7 @@ export async function action(): Promise<void> {
     process.env.NODE_PACKAGE_MANAGER === 'npm' ||
     (process.env.NODE_PACKAGE_MANAGER === 'pnpm' && actionType === 'cjs') ||
     (process.env.NODE_PACKAGE_MANAGER === 'yarn' &&
-      fs.existsSync(path.join(EnvMeta.actionPath, 'node_modules')))
+      fs.existsSync(path.join(actionPath, 'node_modules')))
   ) {
     /**
      * Get the path in the npm cache for each package.
@@ -274,21 +298,7 @@ export async function action(): Promise<void> {
     }
   }
 
-  console.log('')
-  printTitle(CoreMeta.colors.green, 'Running Action')
-  console.log('')
-
-  // The entrypoint is OS-specific. On Windows, it has to start with a leading
-  // slash, then the drive letter, followed by the rest of the path. In both
-  // cases, the path separators are converted to forward slashes.
-  const osEntrypoint =
-    process.platform !== 'win32'
-      ? path.resolve(EnvMeta.entrypoint)
-      : // On Windows, the entrypoint requires a leading slash if the action is
-        // ESM. Otherwise, it can be omitted.
-        actionType === 'esm'
-        ? '/' + path.resolve(EnvMeta.entrypoint)
-        : path.resolve(EnvMeta.entrypoint.replaceAll(path.sep, '/'))
+  const osEntrypoints = getOSEntrypoints(actionType)
 
   // Stub the `@actions/toolkit` libraries and run the action. Quibble and
   // local-action require a different approach depending on if the called action
@@ -296,7 +306,7 @@ export async function action(): Promise<void> {
   // package is installed.
   if (actionType === 'esm') {
     if (stubs['@actions/github'].base)
-      await quibble.esm(
+      await quibble.default.esm(
         path.resolve(
           stubs['@actions/github'].base,
           ...stubs['@actions/github'].lib
@@ -305,7 +315,7 @@ export async function action(): Promise<void> {
       )
 
     if (stubs['@actions/core'].base)
-      await quibble.esm(
+      await quibble.default.esm(
         path.resolve(
           stubs['@actions/core'].base,
           ...stubs['@actions/core'].lib
@@ -314,7 +324,7 @@ export async function action(): Promise<void> {
       )
 
     if (stubs['@actions/artifact'].base)
-      await quibble.esm(
+      await quibble.default.esm(
         path.resolve(
           stubs['@actions/artifact'].base,
           ...stubs['@actions/artifact'].lib
@@ -322,17 +332,53 @@ export async function action(): Promise<void> {
         stubs['@actions/artifact'].stubs
       )
 
-    // ESM actions need to be imported, not required.
-    const { run } = await import(osEntrypoint)
-
-    // Check if the required path is a function.
-    if (typeof run !== 'function')
-      throw new Error(
-        `Entrypoint ${EnvMeta.entrypoint} does not export a run() function`
-      )
-
     try {
+      if (osEntrypoints.pre) {
+        console.log('')
+        printTitle(CoreMeta.colors.red, 'Running Pre Step')
+        console.log('')
+
+        const { run: pre } = await import(osEntrypoints.pre)
+
+        // Check if the required path is a function.
+        if (typeof pre !== 'function')
+          throw new Error(
+            `Entrypoint ${options.pre} does not export a run() function`
+          )
+
+        await pre()
+      }
+
+      console.log('')
+      printTitle(CoreMeta.colors.green, 'Running Action')
+      console.log('')
+
+      // ESM actions need to be imported, not required.
+      const { run } = await import(osEntrypoints.main)
+
+      // Check if the required path is a function.
+      if (typeof run !== 'function')
+        throw new Error(
+          `Entrypoint ${entrypoint} does not export a run() function`
+        )
+
       await run()
+
+      if (osEntrypoints.post) {
+        console.log('')
+        printTitle(CoreMeta.colors.red, 'Running Post Step')
+        console.log('')
+
+        const { run: post } = await import(osEntrypoints.post)
+
+        // Check if the required path is a function.
+        if (typeof post !== 'function')
+          throw new Error(
+            `Entrypoint ${options.post} does not export a run() function`
+          )
+
+        await post()
+      }
     } finally {
       if (process.env.NODE_PACKAGE_MANAGER === 'yarn' && needsReplug)
         replug(fs, packageJsonPath, Object.keys(stubs))
@@ -365,17 +411,55 @@ export async function action(): Promise<void> {
         stubs['@actions/artifact'].stubs
       )
 
-    // CJS actions need to be required, not imported.
-    const { run } = require(osEntrypoint)
-
-    // Check if the required path is a function.
-    if (typeof run !== 'function')
-      throw new Error(
-        `Entrypoint ${EnvMeta.entrypoint} does not export a run() function`
-      )
-
     try {
+      if (osEntrypoints.pre) {
+        console.log('')
+        printTitle(CoreMeta.colors.red, 'Running Pre Step')
+        console.log('')
+
+        // CJS actions need to be required, not imported.
+        const { run: pre } = require(osEntrypoints.pre)
+
+        // Check if the required path is a function.
+        if (typeof pre !== 'function')
+          throw new Error(
+            `Entrypoint ${options.pre} does not export a run() function`
+          )
+
+        await pre()
+      }
+
+      console.log('')
+      printTitle(CoreMeta.colors.green, 'Running Action')
+      console.log('')
+
+      // CJS actions need to be required, not imported.
+      const { run } = require(osEntrypoints.main)
+
+      // Check if the required path is a function.
+      if (typeof run !== 'function')
+        throw new Error(
+          `Entrypoint ${EnvMeta.entrypoint} does not export a run() function`
+        )
+
       await run()
+
+      if (osEntrypoints.post) {
+        console.log('')
+        printTitle(CoreMeta.colors.red, 'Running Post Step')
+        console.log('')
+
+        // CJS actions need to be required, not imported.
+        const { run: post } = require(osEntrypoints.post)
+
+        // Check if the required path is a function.
+        if (typeof post !== 'function')
+          throw new Error(
+            `Entrypoint ${options.post} does not export a run() function`
+          )
+
+        await post()
+      }
     } finally {
       if (process.env.NODE_PACKAGE_MANAGER === 'yarn' && needsReplug)
         replug(fs, packageJsonPath, Object.keys(stubs))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,7 @@ import type { Command } from 'commander'
 import { makeProgram } from './command.js'
 
 /**
- * Runs the CLI program
- *
- * @returns A promise that resolves when the program is finished
+ * Runs the Program
  */
 export async function run(): Promise<void> {
   const chalk = (await import('chalk')).default

--- a/src/stubs/env.ts
+++ b/src/stubs/env.ts
@@ -12,11 +12,16 @@ export const EnvMeta: EnvMetadata = {
   env: {},
   inputs: {},
   outputs: {},
-  path: ''
+  path: '',
+  postEntrypoint: undefined,
+  preEntrypoint: undefined
 }
 
 /**
- * Resets the environment metadata
+ * Reset the Environment Metadata
+ *
+ * Simple convenience function to reset the environment metadata back to initial
+ * state.
  */
 export function ResetEnvMetadata(): void {
   EnvMeta.actionFile = ''
@@ -28,4 +33,6 @@ export function ResetEnvMetadata(): void {
   EnvMeta.inputs = {}
   EnvMeta.outputs = {}
   EnvMeta.path = ''
+  EnvMeta.postEntrypoint = undefined
+  EnvMeta.preEntrypoint = undefined
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,62 +2,51 @@ import type { Artifact } from './stubs/artifact/internal/shared/interfaces.js'
 
 /** Environment Metadata */
 export type EnvMetadata = {
-  /** Path to the `action.yml` file */
+  /** Path to `action.yml` */
   actionFile: string
-
-  /** Path to the action directory */
+  /** Path to Action Directory */
   actionPath: string
-
   /** Map of Action Artifacts */
   artifacts: Artifact[]
-
-  /** Path to the `.env` file */
+  /** Path to `.env` */
   dotenvFile: string
-
-  /** Environment variables */
+  /** Environment Variables */
   env: {
     [key: string]: string | undefined
     TZ?: string | undefined
   }
-
-  /** System path */
+  /** System Path */
   path: string
-
-  /** Inputs defined in `action.yml` */
+  /** Inputs in `action.yml` */
   inputs: { [key: string]: Input }
-
-  /** Outputs defined in `action.yml` */
+  /** Outputs in `action.yml` */
   outputs: { [key: string]: Output }
-
-  /** Pre-transpilation entrypoint for the action (e.g. `src/main.ts`) */
+  /** Pre-Transpilation Action `main` Entrypoint (e.g. `src/main.ts`) */
   entrypoint: string
+  /** Pre-Transpilation Action `pre` Entrypoint (e.g. `pre/main.ts`) */
+  preEntrypoint: string | undefined
+  /** Pre-Transpilation Action `post` Entrypoint (e.g. `post/main.ts`) */
+  postEntrypoint: string | undefined
 }
 
 /** Metadata for `@actions/core` */
 export type CoreMetadata = {
-  /** Command echo setting */
+  /** Command Echo Setting */
   echo: boolean
-
-  /** Exit code (0 = success, 1 = failure) */
+  /** Exit Code (0 = success, 1 = failure) */
   exitCode: 0 | 1
-
-  /** Exit message (empty if success) */
+  /** Exit Message (success = empty) */
   exitMessage: string
-
-  /** Outputs set during action invocation */
+  /** Action Outputs */
   outputs: { [key: string]: string }
-
-  /** Secrets registered during action invocation */
+  /** Registered Secrets */
   secrets: string[]
-
-  /** Actions step debug setting */
+  /** Actions Step Debug Enabled */
   stepDebug: boolean
-
-  /** Current action state */
+  /** Action State */
   state: { [key: string]: string }
-
   /**
-   * Colors used to send output to the console
+   * Output Colors
    *
    * This is not part of `@actions/core` but is included here for convenience
    * when calling related functions.
@@ -65,9 +54,8 @@ export type CoreMetadata = {
   colors: {
     [key: string]: (message: string) => void
   }
-
   /**
-   * The path to the step summary output file.
+   * Step Summary Output File Path
    *
    * This is not part of `@actions/core` but is included here for convenience
    * when calling related functions.
@@ -75,65 +63,52 @@ export type CoreMetadata = {
   stepSummaryPath: string
 }
 
-/** Properties of an `action.yml` */
+/** Action Properties */
 export type Action = {
-  /** Name of the action */
+  /** Name */
   name: string
-
-  /** Author of the action */
+  /** Author */
   author?: string
-
-  /** Description of the action */
+  /** Description */
   description: string
-
-  /** Inputs defined in the action */
+  /** Inputs */
   inputs: Record<string, Input>
-
-  /** Outputs defined in the action */
+  /** Outputs */
   outputs: Record<string, Output>
-
-  /** How the action is invoked */
+  /** Entrypoint Configuration */
   runs: Runs
 }
 
-/** Input properties of an `action.yml` */
+/** Input Properties */
 export type Input = {
-  /** Description of the input */
+  /** Description */
   description: string
-
-  /** Whether the input is required */
+  /** Required */
   required?: boolean
-
-  /** Default value of the input */
+  /** Default ValuE */
   default?: string
-
-  /** Deprecation message for the input */
+  /** Deprecation Message */
   deprecationMessage?: string
 }
 
-/** Output properties of an `action.yml` */
+/** Output Properties */
 export type Output = {
   /** Description of the output */
   description: string
 }
 
-/** How the action is invoked */
+/** Entrypoint Properties */
 export type Runs = {
-  /** Type of event */
+  /** Type of Entrypoint */
   using: string
-
-  /** The entrypoint */
+  /** Entrypoint Script */
   main: string
-
-  /** Script to run at the start of a job (before `main`) */
+  /** Pre Script */
   pre?: string
-
-  /** Conditions for the `pre` script to run */
+  /** Pre Script Conditions */
   'pre-if'?: () => boolean
-
-  /** Script to run at the end of a job (after `main`) */
+  /** Post Script */
   post?: string
-
-  /** Conditions for the `post` script to run */
+  /** Post Script Conditions */
   'post-if'?: () => boolean
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,47 @@
+import path from 'path'
+import { EnvMeta } from '../stubs/env.js'
+
+/**
+ * Get OS Action Entrypoints
+ *
+ * The entrypoint is OS-specific. On Windows, it has to start with a leading
+ * slash, then the drive letter, followed by the rest of the path. In both
+ * cases, the path separators are converted to forward slashes.
+ *
+ * On Windows, the entrypoint requires a leading slash if the action is ESM.
+ * Otherwise, it can be omitted.
+ *
+ * @param actionType Action Type (esm | cjs)
+ * @returns Object with main, pre, and post entrypoints
+ */
+export function getOSEntrypoints(actionType: 'esm' | 'cjs'): {
+  main: string
+  pre: string | undefined
+  post: string | undefined
+} {
+  return {
+    main:
+      process.platform !== 'win32'
+        ? path.resolve(EnvMeta.entrypoint)
+        : /* istanbul ignore next */
+          actionType === 'esm'
+          ? '/' + path.resolve(EnvMeta.entrypoint)
+          : path.resolve(EnvMeta.entrypoint.replaceAll(path.sep, '/')),
+    pre: EnvMeta.preEntrypoint
+      ? process.platform !== 'win32'
+        ? path.resolve(EnvMeta.preEntrypoint)
+        : /* istanbul ignore next */
+          actionType === 'esm'
+          ? '/' + path.resolve(EnvMeta.preEntrypoint)
+          : path.resolve(EnvMeta.preEntrypoint.replaceAll(path.sep, '/'))
+      : undefined,
+    post: EnvMeta.postEntrypoint
+      ? process.platform !== 'win32'
+        ? path.resolve(EnvMeta.postEntrypoint)
+        : /* istanbul ignore next */
+          actionType === 'esm'
+          ? '/' + path.resolve(EnvMeta.postEntrypoint)
+          : path.resolve(EnvMeta.postEntrypoint.replaceAll(path.sep, '/'))
+      : undefined
+  }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -10,6 +10,7 @@
     "__fixtures__/@octokit/",
     "__fixtures__/crypto.ts",
     "__fixtures__/fs.ts",
+    "__fixtures__/path.ts",
     "__fixtures__/tsconfig-paths.ts",
     "__tests__",
     "src",


### PR DESCRIPTION
This pull request introduces support for `pre` and `post` scripts in GitHub Actions, updates documentation to reflect these changes, and adds fixtures to test the functionality across different languages and module systems.

Closes #183 

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R13): Added an entry for version 4, highlighting support for `pre` and `post` scripts in GitHub Actions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L185-R213): Updated the `local-action run` command to include optional `--pre` and `--post` arguments, along with examples and descriptions for their usage.

### Fixture Additions for `pre` and `post` Scripts:
* JavaScript Fixtures:
  - Added `pre` and `post` scripts with `index.js` and `main.js` files in `__fixtures__/javascript/success` and `__fixtures__/javascript-esm/success`. These scripts demonstrate basic input handling and output setting for actions. [[1]](diffhunk://#diff-f8541f0b923ac556ae7560287567c67d2bac46beb480a11ee286b5fe5603d73dR1-R3) [[2]](diffhunk://#diff-13b3808981fc67a311be46f6573b193dcfda3dac1699c1e934287249cdcd7b63R1-R13)
* TypeScript Fixtures:
  - Added `pre` and `post` scripts with `index.ts` and `main.ts` files in `__fixtures__/typescript/success` and `__fixtures__/typescript-esm/success`. These scripts showcase similar functionality as the JavaScript fixtures but with TypeScript syntax. [[1]](diffhunk://#diff-92977f7e53208fa72e2158e41d5402f216d40720463ecd30f2a2f00781c66f65R1-R3) [[2]](diffhunk://#diff-d61a1b02638db9fb7d01bdf456f72897331cdfc738572de62445b52b13b370dbR1-R9) [[3]](diffhunk://#diff-26abda3a139ba9b44e9ef716318f64217b26df0165d0ed9fb1cc2b6acc4b1cecR1-R3) [[4]](diffhunk://#diff-aeff2990bef1136e31d03757577627865298369c2286e6c2a7c4fa58f929b0c1R1-R9)

### Utility Mock:
* [`__fixtures__/path.ts`](diffhunk://#diff-92b0347f0720c1eaba4d2f5d1e79e0e96de62442f21dc09e1d7faf51aed10042R1-R7): Added a mock implementation of the `resolve` function using Jest for testing purposes.