### PR TITLE
Remove bootstrap script call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5
+
+Removes support for custom `paths` in the target action's `tsconfig.json`. This
+appears to have been causing issues with type-stripping and later versions of
+Node.js.
+
 ## v4
 
 This version adds support for

--- a/bin/local-action.js
+++ b/bin/local-action.js
@@ -32,11 +32,6 @@ function entrypoint() {
         ? path.join(packagePath, 'src', 'bootstrap.ts').replaceAll('\\', '\\\\')
         : path.join(packagePath, 'src', 'bootstrap.ts')
 
-    // Require the bootstrap script in NODE_OPTIONS.
-    process.env.NODE_OPTIONS = process.env.NODE_OPTIONS
-      ? `${process.env.NODE_OPTIONS} --require "${bootstrapPath}"`
-      : `--require "${bootstrapPath}"`
-
     // Disable experimental warnings.
     process.env.NODE_NO_WARNINGS = 1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,


### PR DESCRIPTION
This pull request updates the package version to `5.0.0` and removes support for custom `paths` in the target action's `tsconfig.json` due to compatibility issues with type-stripping and newer versions of Node.js.