### PR TITLE
Bump version to 5.0.1 and fix help command formatting

### DIFF
--- a/bin/local-action.js
+++ b/bin/local-action.js
@@ -55,7 +55,7 @@ function entrypoint() {
     // If the TARGET_ACTION_PATH environment variable is not set, display the
     // help message.
     if (!process.env.TARGET_ACTION_PATH) {
-      command += `-- --help`
+      command += ` -- --help`
       execSync(command, { stdio: 'inherit' })
       return
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/local-action",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/local-action",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@github/local-action",
   "description": "Local Debugging for GitHub Actions",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "type": "module",
   "author": "Nick Alteen <ncalteen@github.com>",
   "private": false,


### PR DESCRIPTION
Fixes the help command spacing issue referenced in #205 

Closes #205